### PR TITLE
devise_token_authを用いた新規登録サインインを実装

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,3 +13,9 @@ Style/Documentation:
 
 Metrics/AbcSize:
   Max: 25
+
+Metrics/BlockLength:
+  Max: 40
+
+RSpec/ContextWording:
+  Enabled: false

--- a/app/controllers/api_controler.rb
+++ b/app/controllers/api_controler.rb
@@ -1,2 +1,3 @@
 class ApiController < ActionController::API
+  include DeviseTokenAuth::Concerns::SetUserByToken
 end

--- a/app/controllers/api_controler.rb
+++ b/app/controllers/api_controler.rb
@@ -1,3 +1,0 @@
-class ApiController < ActionController::API
-  include DeviseTokenAuth::Concerns::SetUserByToken
-end

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -1,0 +1,6 @@
+class ApiController < ActionController::API
+  include DeviseTokenAuth::Concerns::SetUserByToken
+  skip_before_action :verify_authenticity_token, if: :devise_controller?, raise: false
+
+  helper_method :current_user, :user_signed_in?
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,6 @@
 class ApplicationController < ActionController::Base
+  include DeviseTokenAuth::Concerns::SetUserByToken
+  skip_before_action :verify_authenticity_token, if: :devise_controller?, raise: false
+
+  helper_method :current_user, :user_signed_in?
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,2 @@
 class ApplicationController < ActionController::Base
-  include DeviseTokenAuth::Concerns::SetUserByToken
-  skip_before_action :verify_authenticity_token, if: :devise_controller?, raise: false
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,4 @@
 class ApplicationController < ActionController::Base
   include DeviseTokenAuth::Concerns::SetUserByToken
+  skip_before_action :verify_authenticity_token, if: :devise_controller?, raise: false
 end

--- a/app/controllers/v1/auth/registrations_controller.rb
+++ b/app/controllers/v1/auth/registrations_controller.rb
@@ -1,0 +1,2 @@
+class V1::Auth::RegistrationsController < ApplicationController
+end

--- a/app/controllers/v1/auth/registrations_controller.rb
+++ b/app/controllers/v1/auth/registrations_controller.rb
@@ -1,3 +1,2 @@
 class V1::Auth::RegistrationsController < DeviseTokenAuth::RegistrationsController
-  
 end

--- a/app/controllers/v1/auth/registrations_controller.rb
+++ b/app/controllers/v1/auth/registrations_controller.rb
@@ -1,6 +1,8 @@
 module V1
   module Auth
-    class RegistrationsController < ApiController
+    class RegistrationsController < DeviseTokenAuth::RegistrationsController
+      # before_action :sign_up_params,                only: :create
+
       private
 
       def sign_up_params

--- a/app/controllers/v1/auth/registrations_controller.rb
+++ b/app/controllers/v1/auth/registrations_controller.rb
@@ -1,2 +1,6 @@
-class V1::Auth::RegistrationsController < ApiController
+module V1
+  module Auth
+    class RegistrationsController < ApiController
+    end
+  end
 end

--- a/app/controllers/v1/auth/registrations_controller.rb
+++ b/app/controllers/v1/auth/registrations_controller.rb
@@ -1,2 +1,3 @@
-class V1::Auth::RegistrationsController < ApplicationController
+class V1::Auth::RegistrationsController < DeviseTokenAuth::RegistrationsController
+  
 end

--- a/app/controllers/v1/auth/registrations_controller.rb
+++ b/app/controllers/v1/auth/registrations_controller.rb
@@ -1,2 +1,2 @@
-class V1::Auth::RegistrationsController < DeviseTokenAuth::RegistrationsController
+class V1::Auth::RegistrationsController < ApiController
 end

--- a/app/controllers/v1/auth/registrations_controller.rb
+++ b/app/controllers/v1/auth/registrations_controller.rb
@@ -1,6 +1,11 @@
 module V1
   module Auth
     class RegistrationsController < ApiController
+      private
+
+      def sign_up_params
+        params.permit(:email, :password, :password_confirmation)
+      end
     end
   end
 end

--- a/app/controllers/v1/auth/sessions_controller.rb
+++ b/app/controllers/v1/auth/sessions_controller.rb
@@ -1,0 +1,14 @@
+# ログイン状態確認用コントローラー
+module V1
+  module Auth
+    class SessionsController < ApiController
+      def index
+        if current_api_v1_user
+          render json: { is_login: true, data: current_api_v1_user }
+        else
+          render json: { is_login: false, message: "ユーザーが存在しません" }
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/v1/hotels_controller.rb
+++ b/app/controllers/v1/hotels_controller.rb
@@ -1,0 +1,2 @@
+class V1::HotelsController < ApplicationController
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,5 +7,4 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable,
          :lockable
   include DeviseTokenAuth::Concerns::User
-  
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,7 +4,6 @@ class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable,
-         :lockable
+         :recoverable, :rememberable, :lockable, :validatable
   include DeviseTokenAuth::Concerns::User
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,4 +7,5 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable,
          :lockable
   include DeviseTokenAuth::Concerns::User
+  
 end

--- a/config/database.yml
+++ b/config/database.yml
@@ -13,9 +13,9 @@ default: &default
   adapter: mysql2
   encoding: utf8mb4
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-  username: root
-  password: password
-  host: db
+  username: <%= ENV['DATABASE_DEV_USER'] %>
+  password: <%= ENV['DATABASE_DEV_PASSWORD'] %>
+  host: <%= ENV['DATABASE_DEV_HOST'] %>
 
 development:
   <<: *default

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -37,8 +37,8 @@ Rails.application.configure do
   config.active_storage.service = :local
 
   # Don't care if the mailer can't send.
-  config.action_mailer.default_url_options = { host: ENV['SERVER_DEV_HOST'], port: ENV['SERVER_DEV_PORT'] }
-  
+  config.action_mailer.default_url_options = { host: ENV.fetch('SERVER_DEV_HOST', nil), port: ENV.fetch('SERVER_DEV_PORT', nil) }
+
   config.action_mailer.raise_delivery_errors = false
 
   config.action_mailer.perform_caching = false

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -37,6 +37,8 @@ Rails.application.configure do
   config.active_storage.service = :local
 
   # Don't care if the mailer can't send.
+  config.action_mailer.default_url_options = { host: ENV['SERVER_DEV_HOST'], port: ENV['SERVER_DEV_PORT'] }
+  
   config.action_mailer.raise_delivery_errors = false
 
   config.action_mailer.perform_caching = false

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -4,6 +4,7 @@ Rails.application.config.middleware.insert_before 0, Rack::Cors do
 
     resource '*',
       headers: :any,
+      expose: ["access-token", "expiry", "token-type", "uid", "client"],
       methods: [:get, :post, :put, :patch, :delete, :options, :head]
   end
 end

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -4,7 +4,7 @@ Rails.application.config.middleware.insert_before 0, Rack::Cors do
 
     resource '*',
       headers: :any,
-      expose: ["access-token", "expiry", "token-type", "uid", "client"],
+      expose: %w[access-token expiry token-type uid client],
       methods: [:get, :post, :put, :patch, :delete, :options, :head]
   end
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -178,12 +178,12 @@ Devise.setup do |config|
 
   # ==> Configuration for :validatable
   # Range for password length.
-  config.password_length = 6..128
+  config.password_length = 8..128
 
   # Email regex used to validate email formats. It simply asserts that
   # one (and only one) @ exists in the given string. This is mainly
   # to give user feedback and not to assert the e-mail validity.
-  config.email_regexp = /\A[^@\s]+@[^@\s]+\z/
+  config.email_regexp = /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i
 
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this

--- a/config/initializers/devise_token_auth.rb
+++ b/config/initializers/devise_token_auth.rb
@@ -42,11 +42,11 @@ DeviseTokenAuth.setup do |config|
   # config.default_callbacks = true
 
   # Makes it possible to change the headers names
-  # config.headers_names = {:'access-token' => 'access-token',
-  #                        :'client' => 'client',
-  #                        :'expiry' => 'expiry',
-  #                        :'uid' => 'uid',
-  #                        :'token-type' => 'token-type' }
+  config.headers_names = {:'access-token' => 'access-token',
+                         :'client' => 'client',
+                         :'expiry' => 'expiry',
+                         :'uid' => 'uid',
+                         :'token-type' => 'token-type' }
 
   # By default, only Bearer Token authentication is implemented out of the box.
   # If, however, you wish to integrate with legacy Devise authentication, you can

--- a/config/initializers/devise_token_auth.rb
+++ b/config/initializers/devise_token_auth.rb
@@ -42,11 +42,11 @@ DeviseTokenAuth.setup do |config|
   # config.default_callbacks = true
 
   # Makes it possible to change the headers names
-  config.headers_names = {:'access-token' => 'access-token',
-                         :'client' => 'client',
-                         :'expiry' => 'expiry',
-                         :'uid' => 'uid',
-                         :'token-type' => 'token-type' }
+  config.headers_names = { 'access-token': 'access-token',
+                           client: 'client',
+                           expiry: 'expiry',
+                           uid: 'uid',
+                           'token-type': 'token-type' }
 
   # By default, only Bearer Token authentication is implemented out of the box.
   # If, however, you wish to integrate with legacy Devise authentication, you can

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 Rails.application.routes.draw do
-  mount_devise_token_auth_for 'User', at: 'auth'
-  mount RailsAdmin::Engine => '/admin', as: 'rails_admin'
+  namespace :v1 do
+    mount_devise_token_auth_for 'User', at: 'auth'
+    mount RailsAdmin::Engine => '/admin', as: 'rails_admin'
+  end
   resources :posts, only: :index
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,12 @@
 Rails.application.routes.draw do
-  namespace :v1 do
-    mount_devise_token_auth_for 'User', at: 'auth'
-    mount RailsAdmin::Engine => '/admin', as: 'rails_admin'
-  end
   resources :posts, only: :index
+    namespace :v1 do
+      mount RailsAdmin::Engine => '/admin', as: 'rails_admin'
+      mount_devise_token_auth_for 'User', at: 'auth', controllers: {
+        registrations: 'v1/auth/registrations'
+      }
+        namespace :auth do
+          resources :sessions, only: %i[index]
+        end
+    end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,12 +1,12 @@
 Rails.application.routes.draw do
   resources :posts, only: :index
-    namespace :v1 do
-      mount RailsAdmin::Engine => '/admin', as: 'rails_admin'
-      mount_devise_token_auth_for 'User', at: 'auth', controllers: {
-        registrations: 'v1/auth/registrations'
-      }
-        namespace :auth do
-          resources :sessions, only: %i[index]
-        end
+  namespace :v1 do
+    mount RailsAdmin::Engine => '/admin', as: 'rails_admin'
+    mount_devise_token_auth_for 'User', at: 'auth', controllers: {
+      registrations: 'v1/auth/registrations'
+    }
+    namespace :auth do
+      resources :sessions, only: %i[index]
     end
+  end
 end

--- a/coverage/.resultset.json
+++ b/coverage/.resultset.json
@@ -713,19 +713,7 @@
       },
       "/app/spec/requests/v1/auth/auth_users_apis_spec.rb": {
         "lines": [
-          1,
-          null,
-          1,
-          1,
-          1,
-          1,
-          1,
-          0,
-          0,
-          null,
-          null,
-          null,
-          null
+
         ]
       },
       "/app/spec/requests/v1/auth/registrations_spec.rb": {
@@ -735,11 +723,17 @@
           1,
           1,
           1,
+          1,
+          null,
+          1,
+          0,
+          null,
+          null,
           null,
           null
         ]
       }
     },
-    "timestamp": 1655109605
+    "timestamp": 1655112692
   }
 }

--- a/coverage/.resultset.json
+++ b/coverage/.resultset.json
@@ -377,6 +377,7 @@
           null,
           null,
           null,
+          1,
           null,
           null,
           null,
@@ -386,18 +387,17 @@
           null,
           null,
           null,
+          1,
           null,
           null,
           null,
+          1,
           null,
           null,
+          1,
           null,
           null,
-          null,
-          null,
-          null,
-          null,
-          null,
+          1,
           null,
           null,
           null,
@@ -610,6 +610,12 @@
           1,
           1,
           null,
+          1,
+          0,
+          0,
+          null,
+          null,
+          null,
           null,
           null,
           null,
@@ -657,6 +663,8 @@
           1,
           1,
           1,
+          null,
+          1,
           null
         ]
       },
@@ -669,6 +677,7 @@
           null,
           1,
           null,
+          null,
           1,
           null
         ]
@@ -680,10 +689,12 @@
           null
         ]
       },
-      "/app/spec/factories/posts.rb": {
+      "/app/spec/factories/users.rb": {
         "lines": [
           1,
-          null,
+          1,
+          1,
+          1,
           null,
           null
         ]
@@ -699,8 +710,36 @@
           1,
           null
         ]
+      },
+      "/app/spec/requests/v1/auth/auth_users_apis_spec.rb": {
+        "lines": [
+          1,
+          null,
+          1,
+          1,
+          1,
+          1,
+          1,
+          0,
+          0,
+          null,
+          null,
+          null,
+          null
+        ]
+      },
+      "/app/spec/requests/v1/auth/registrations_spec.rb": {
+        "lines": [
+          1,
+          null,
+          1,
+          1,
+          1,
+          null,
+          null
+        ]
       }
     },
-    "timestamp": 1654865727
+    "timestamp": 1655109605
   }
 }

--- a/coverage/.resultset.json
+++ b/coverage/.resultset.json
@@ -701,6 +701,7 @@
           1,
           1,
           1,
+          1,
           null,
           null
         ]
@@ -709,6 +710,11 @@
         "lines": [
           1,
           null
+        ]
+      },
+      "/app/spec/support/authorization_spec.rb": {
+        "lines": [
+
         ]
       },
       "/app/app/models/post.rb": {
@@ -725,6 +731,7 @@
           1,
           1,
           1,
+          null,
           1,
           1,
           0,
@@ -746,6 +753,6 @@
         ]
       }
     },
-    "timestamp": 1655129479
+    "timestamp": 1655133694
   }
 }

--- a/coverage/.resultset.json
+++ b/coverage/.resultset.json
@@ -176,6 +176,7 @@
           null,
           null,
           null,
+          null,
           null
         ]
       },
@@ -540,7 +541,7 @@
           null,
           null,
           null,
-          null,
+          1,
           null,
           null,
           null,
@@ -663,8 +664,13 @@
           1,
           1,
           1,
+          1,
+          null,
           null,
           1,
+          1,
+          null,
+          null,
           null
         ]
       },
@@ -713,7 +719,19 @@
       },
       "/app/spec/requests/v1/auth/auth_users_apis_spec.rb": {
         "lines": [
-
+          1,
+          null,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          0,
+          null,
+          null,
+          null,
+          null
         ]
       },
       "/app/spec/requests/v1/auth/registrations_spec.rb": {
@@ -723,17 +741,11 @@
           1,
           1,
           1,
-          1,
-          null,
-          1,
-          0,
-          null,
-          null,
           null,
           null
         ]
       }
     },
-    "timestamp": 1655112692
+    "timestamp": 1655129479
   }
 }

--- a/coverage/index.html
+++ b/coverage/index.html
@@ -14,7 +14,7 @@
       <img src="./assets/0.12.3/loading.gif" alt="loading"/>
     </div>
     <div id="wrapper" class="hide">
-      <div class="timestamp">Generated <abbr class="timeago" title="2022-06-13T18:31:32+09:00">2022-06-13T18:31:32+09:00</abbr></div>
+      <div class="timestamp">Generated <abbr class="timeago" title="2022-06-13T23:11:19+09:00">2022-06-13T23:11:19+09:00</abbr></div>
       <ul class="group_tabs"></ul>
 
       <div id="content">
@@ -23,7 +23,7 @@
     <span class="group_name">All Files</span>
     (<span class="covered_percent">
       <span class="green">
-  96.97%
+  97.2%
 </span>
 
      </span>
@@ -43,11 +43,11 @@
   </div>
 
   <div class="t-line-summary">
-    <b>99</b> relevant lines,
-    <span class="green"><b>96</b> lines covered</span> and
+    <b>107</b> relevant lines,
+    <span class="green"><b>104</b> lines covered</span> and
     <span class="red"><b>3</b> lines missed. </span>
     (<span class="green">
-  96.97%
+  97.2%
 </span>
 )
   </div>
@@ -183,7 +183,7 @@
           <tr class="t-file">
             <td class="strong t-file__name"><a href="#d488c6da2ba90804c394c7dbec66f5d7956b0d42" class="src_link" title="config/initializers/cors.rb">config/initializers/cors.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
-            <td class="cell--number">9</td>
+            <td class="cell--number">10</td>
             <td class="cell--number">4</td>
             <td class="cell--number">4</td>
             <td class="cell--number">0</td>
@@ -206,8 +206,8 @@
             <td class="strong t-file__name"><a href="#2c3c375ea9c039d240641f2b50c5f6058a50bdcc" class="src_link" title="config/initializers/devise_token_auth.rb">config/initializers/devise_token_auth.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">60</td>
-            <td class="cell--number">2</td>
-            <td class="cell--number">2</td>
+            <td class="cell--number">3</td>
+            <td class="cell--number">3</td>
             <td class="cell--number">0</td>
             <td class="cell--number">1.00</td>
             
@@ -260,9 +260,9 @@
           <tr class="t-file">
             <td class="strong t-file__name"><a href="#056289cd38b96f93ffdda478bab2d38195c6ce01" class="src_link" title="config/routes.rb">config/routes.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
+            <td class="cell--number">12</td>
             <td class="cell--number">7</td>
-            <td class="cell--number">5</td>
-            <td class="cell--number">5</td>
+            <td class="cell--number">7</td>
             <td class="cell--number">0</td>
             <td class="cell--number">1.00</td>
             
@@ -281,23 +281,23 @@
         
           <tr class="t-file">
             <td class="strong t-file__name"><a href="#41b9cd9b5be863914cc167be6d1e6add1e2b2236" class="src_link" title="spec/requests/v1/auth/auth_users_apis_spec.rb">spec/requests/v1/auth/auth_users_apis_spec.rb</a></td>
-            <td class="green strong cell--number t-file__coverage">100.00 %</td>
-            <td class="cell--number">0</td>
-            <td class="cell--number">0</td>
-            <td class="cell--number">0</td>
-            <td class="cell--number">0</td>
-            <td class="cell--number">0.00</td>
+            <td class="yellow strong cell--number t-file__coverage">87.50 %</td>
+            <td class="cell--number">13</td>
+            <td class="cell--number">8</td>
+            <td class="cell--number">7</td>
+            <td class="cell--number">1</td>
+            <td class="cell--number">0.88</td>
             
           </tr>
         
           <tr class="t-file">
             <td class="strong t-file__name"><a href="#1730250746a5ba1a01b0b4c373931423a4163a91" class="src_link" title="spec/requests/v1/auth/registrations_spec.rb">spec/requests/v1/auth/registrations_spec.rb</a></td>
-            <td class="yellow strong cell--number t-file__coverage">85.71 %</td>
-            <td class="cell--number">13</td>
+            <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">7</td>
-            <td class="cell--number">6</td>
-            <td class="cell--number">1</td>
-            <td class="cell--number">0.86</td>
+            <td class="cell--number">4</td>
+            <td class="cell--number">4</td>
+            <td class="cell--number">0</td>
+            <td class="cell--number">1.00</td>
             
           </tr>
         
@@ -2465,7 +2465,7 @@
 
             
 
-            <code class="ruby">      methods: [:get, :post, :put, :patch, :delete, :options, :head]</code>
+            <code class="ruby">      expose: %w[access-token expiry token-type uid client],</code>
           </li>
         </div>
       
@@ -2476,12 +2476,23 @@
 
             
 
-            <code class="ruby">  end</code>
+            <code class="ruby">      methods: [:get, :post, :put, :patch, :delete, :options, :head]</code>
           </li>
         </div>
       
         <div>
           <li class="never" data-hits="" data-linenumber="9">
+            
+            
+
+            
+
+            <code class="ruby">  end</code>
+          </li>
+        </div>
+      
+        <div>
+          <li class="never" data-hits="" data-linenumber="10">
             
             
 
@@ -5962,8 +5973,8 @@
     
 
     <div class="t-line-summary">
-      <b>2</b> relevant lines.
-      <span class="green"><b>2</b> lines covered</span> and
+      <b>3</b> relevant lines.
+      <span class="green"><b>3</b> lines covered</span> and
       <span class="red"><b>0</b> lines missed.</span>
     </div>
 
@@ -6459,13 +6470,13 @@
         </div>
       
         <div>
-          <li class="never" data-hits="" data-linenumber="45">
-            
-            
-
+          <li class="covered" data-hits="1" data-linenumber="45">
+            <span class="hits">1</span>
             
 
-            <code class="ruby">  # config.headers_names = {:&#39;access-token&#39; =&gt; &#39;access-token&#39;,</code>
+            
+
+            <code class="ruby">  config.headers_names = { &#39;access-token&#39;: &#39;access-token&#39;,</code>
           </li>
         </div>
       
@@ -6476,7 +6487,7 @@
 
             
 
-            <code class="ruby">  #                        :&#39;client&#39; =&gt; &#39;client&#39;,</code>
+            <code class="ruby">                           client: &#39;client&#39;,</code>
           </li>
         </div>
       
@@ -6487,7 +6498,7 @@
 
             
 
-            <code class="ruby">  #                        :&#39;expiry&#39; =&gt; &#39;expiry&#39;,</code>
+            <code class="ruby">                           expiry: &#39;expiry&#39;,</code>
           </li>
         </div>
       
@@ -6498,7 +6509,7 @@
 
             
 
-            <code class="ruby">  #                        :&#39;uid&#39; =&gt; &#39;uid&#39;,</code>
+            <code class="ruby">                           uid: &#39;uid&#39;,</code>
           </li>
         </div>
       
@@ -6509,7 +6520,7 @@
 
             
 
-            <code class="ruby">  #                        :&#39;token-type&#39; =&gt; &#39;token-type&#39; }</code>
+            <code class="ruby">                           &#39;token-type&#39;: &#39;token-type&#39; }</code>
           </li>
         </div>
       
@@ -7690,8 +7701,8 @@
     
 
     <div class="t-line-summary">
-      <b>5</b> relevant lines.
-      <span class="green"><b>5</b> lines covered</span> and
+      <b>7</b> relevant lines.
+      <span class="green"><b>7</b> lines covered</span> and
       <span class="red"><b>0</b> lines missed.</span>
     </div>
 
@@ -7720,7 +7731,7 @@
 
             
 
-            <code class="ruby">  namespace :v1 do</code>
+            <code class="ruby">  resources :posts, only: :index</code>
           </li>
         </div>
       
@@ -7731,7 +7742,7 @@
 
             
 
-            <code class="ruby">    mount_devise_token_auth_for &#39;User&#39;, at: &#39;auth&#39;</code>
+            <code class="ruby">  namespace :v1 do</code>
           </li>
         </div>
       
@@ -7747,7 +7758,73 @@
         </div>
       
         <div>
-          <li class="never" data-hits="" data-linenumber="5">
+          <li class="covered" data-hits="1" data-linenumber="5">
+            <span class="hits">1</span>
+            
+
+            
+
+            <code class="ruby">    mount_devise_token_auth_for &#39;User&#39;, at: &#39;auth&#39;, controllers: {</code>
+          </li>
+        </div>
+      
+        <div>
+          <li class="never" data-hits="" data-linenumber="6">
+            
+            
+
+            
+
+            <code class="ruby">      registrations: &#39;v1/auth/registrations&#39;</code>
+          </li>
+        </div>
+      
+        <div>
+          <li class="never" data-hits="" data-linenumber="7">
+            
+            
+
+            
+
+            <code class="ruby">    }</code>
+          </li>
+        </div>
+      
+        <div>
+          <li class="covered" data-hits="1" data-linenumber="8">
+            <span class="hits">1</span>
+            
+
+            
+
+            <code class="ruby">    namespace :auth do</code>
+          </li>
+        </div>
+      
+        <div>
+          <li class="covered" data-hits="1" data-linenumber="9">
+            <span class="hits">1</span>
+            
+
+            
+
+            <code class="ruby">      resources :sessions, only: %i[index]</code>
+          </li>
+        </div>
+      
+        <div>
+          <li class="never" data-hits="" data-linenumber="10">
+            
+            
+
+            
+
+            <code class="ruby">    end</code>
+          </li>
+        </div>
+      
+        <div>
+          <li class="never" data-hits="" data-linenumber="11">
             
             
 
@@ -7758,18 +7835,7 @@
         </div>
       
         <div>
-          <li class="covered" data-hits="1" data-linenumber="6">
-            <span class="hits">1</span>
-            
-
-            
-
-            <code class="ruby">  resources :posts, only: :index</code>
-          </li>
-        </div>
-      
-        <div>
-          <li class="never" data-hits="" data-linenumber="7">
+          <li class="never" data-hits="" data-linenumber="12">
             
             
 
@@ -7885,39 +7951,8 @@
   <div class="header">
     <h3>spec/requests/v1/auth/auth_users_apis_spec.rb</h3>
     <h4>
-      <span class="green">
-  100.0%
-</span>
-
-      lines covered
-    </h4>
-
-    
-
-    <div class="t-line-summary">
-      <b>0</b> relevant lines.
-      <span class="green"><b>0</b> lines covered</span> and
-      <span class="red"><b>0</b> lines missed.</span>
-    </div>
-
-    
-
-  </div>
-
-  <pre>
-    <ol>
-      
-    </ol>
-  </pre>
-</div>
-
-      
-        <div class="source_table" id="1730250746a5ba1a01b0b4c373931423a4163a91">
-  <div class="header">
-    <h3>spec/requests/v1/auth/registrations_spec.rb</h3>
-    <h4>
       <span class="yellow">
-  85.71%
+  87.5%
 </span>
 
       lines covered
@@ -7926,8 +7961,8 @@
     
 
     <div class="t-line-summary">
-      <b>7</b> relevant lines.
-      <span class="green"><b>6</b> lines covered</span> and
+      <b>8</b> relevant lines.
+      <span class="green"><b>7</b> lines covered</span> and
       <span class="red"><b>1</b> lines missed.</span>
     </div>
 
@@ -8005,13 +8040,13 @@
         </div>
       
         <div>
-          <li class="never" data-hits="" data-linenumber="7">
-            
-            
-
+          <li class="covered" data-hits="1" data-linenumber="7">
+            <span class="hits">1</span>
             
 
-            <code class="ruby">        # client_user = build(:user)</code>
+            
+
+            <code class="ruby">        params = { email: &#39;test2@example.com&#39;, password: &#39;test2525&#39; }</code>
           </li>
         </div>
       
@@ -8022,7 +8057,7 @@
 
             
 
-            <code class="ruby">        post v1_auth_path, params = { email: &#39;test2@example.com&#39;, password: &#39;test2525&#39; } </code>
+            <code class="ruby">        post v1_auth_path, params: params</code>
           </li>
         </div>
       
@@ -8072,6 +8107,114 @@
       
         <div>
           <li class="never" data-hits="" data-linenumber="13">
+            
+            
+
+            
+
+            <code class="ruby">end</code>
+          </li>
+        </div>
+      
+    </ol>
+  </pre>
+</div>
+
+      
+        <div class="source_table" id="1730250746a5ba1a01b0b4c373931423a4163a91">
+  <div class="header">
+    <h3>spec/requests/v1/auth/registrations_spec.rb</h3>
+    <h4>
+      <span class="green">
+  100.0%
+</span>
+
+      lines covered
+    </h4>
+
+    
+
+    <div class="t-line-summary">
+      <b>4</b> relevant lines.
+      <span class="green"><b>4</b> lines covered</span> and
+      <span class="red"><b>0</b> lines missed.</span>
+    </div>
+
+    
+
+  </div>
+
+  <pre>
+    <ol>
+      
+        <div>
+          <li class="covered" data-hits="1" data-linenumber="1">
+            <span class="hits">1</span>
+            
+
+            
+
+            <code class="ruby">require &#39;rails_helper&#39;</code>
+          </li>
+        </div>
+      
+        <div>
+          <li class="never" data-hits="" data-linenumber="2">
+            
+            
+
+            
+
+            <code class="ruby"></code>
+          </li>
+        </div>
+      
+        <div>
+          <li class="covered" data-hits="1" data-linenumber="3">
+            <span class="hits">1</span>
+            
+
+            
+
+            <code class="ruby">RSpec.describe &quot;V1::Auth::Registrations&quot;, type: :request do</code>
+          </li>
+        </div>
+      
+        <div>
+          <li class="covered" data-hits="1" data-linenumber="4">
+            <span class="hits">1</span>
+            
+
+            
+
+            <code class="ruby">  describe &quot;GET /index&quot; do</code>
+          </li>
+        </div>
+      
+        <div>
+          <li class="covered" data-hits="1" data-linenumber="5">
+            <span class="hits">1</span>
+            
+
+            
+
+            <code class="ruby">    pending &quot;add some examples (or delete) #{__FILE__}&quot;</code>
+          </li>
+        </div>
+      
+        <div>
+          <li class="never" data-hits="" data-linenumber="6">
+            
+            
+
+            
+
+            <code class="ruby">  end</code>
+          </li>
+        </div>
+      
+        <div>
+          <li class="never" data-hits="" data-linenumber="7">
             
             
 

--- a/coverage/index.html
+++ b/coverage/index.html
@@ -14,7 +14,7 @@
       <img src="./assets/0.12.3/loading.gif" alt="loading"/>
     </div>
     <div id="wrapper" class="hide">
-      <div class="timestamp">Generated <abbr class="timeago" title="2022-06-13T17:40:06+09:00">2022-06-13T17:40:06+09:00</abbr></div>
+      <div class="timestamp">Generated <abbr class="timeago" title="2022-06-13T18:31:32+09:00">2022-06-13T18:31:32+09:00</abbr></div>
       <ul class="group_tabs"></ul>
 
       <div id="content">
@@ -23,14 +23,14 @@
     <span class="group_name">All Files</span>
     (<span class="covered_percent">
       <span class="green">
-  96.15%
+  96.97%
 </span>
 
      </span>
      covered at
      <span class="covered_strength">
        <span class="red">
-         0.96
+         0.97
        </span>
     </span> hits/line
     )
@@ -43,11 +43,11 @@
   </div>
 
   <div class="t-line-summary">
-    <b>104</b> relevant lines,
-    <span class="green"><b>100</b> lines covered</span> and
-    <span class="red"><b>4</b> lines missed. </span>
+    <b>99</b> relevant lines,
+    <span class="green"><b>96</b> lines covered</span> and
+    <span class="red"><b>3</b> lines missed. </span>
     (<span class="green">
-  96.15%
+  96.97%
 </span>
 )
   </div>
@@ -281,23 +281,23 @@
         
           <tr class="t-file">
             <td class="strong t-file__name"><a href="#41b9cd9b5be863914cc167be6d1e6add1e2b2236" class="src_link" title="spec/requests/v1/auth/auth_users_apis_spec.rb">spec/requests/v1/auth/auth_users_apis_spec.rb</a></td>
-            <td class="red strong cell--number t-file__coverage">75.00 %</td>
-            <td class="cell--number">13</td>
-            <td class="cell--number">8</td>
-            <td class="cell--number">6</td>
-            <td class="cell--number">2</td>
-            <td class="cell--number">0.75</td>
+            <td class="green strong cell--number t-file__coverage">100.00 %</td>
+            <td class="cell--number">0</td>
+            <td class="cell--number">0</td>
+            <td class="cell--number">0</td>
+            <td class="cell--number">0</td>
+            <td class="cell--number">0.00</td>
             
           </tr>
         
           <tr class="t-file">
             <td class="strong t-file__name"><a href="#1730250746a5ba1a01b0b4c373931423a4163a91" class="src_link" title="spec/requests/v1/auth/registrations_spec.rb">spec/requests/v1/auth/registrations_spec.rb</a></td>
-            <td class="green strong cell--number t-file__coverage">100.00 %</td>
+            <td class="yellow strong cell--number t-file__coverage">85.71 %</td>
+            <td class="cell--number">13</td>
             <td class="cell--number">7</td>
-            <td class="cell--number">4</td>
-            <td class="cell--number">4</td>
-            <td class="cell--number">0</td>
-            <td class="cell--number">1.00</td>
+            <td class="cell--number">6</td>
+            <td class="cell--number">1</td>
+            <td class="cell--number">0.86</td>
             
           </tr>
         
@@ -7885,8 +7885,8 @@
   <div class="header">
     <h3>spec/requests/v1/auth/auth_users_apis_spec.rb</h3>
     <h4>
-      <span class="red">
-  75.0%
+      <span class="green">
+  100.0%
 </span>
 
       lines covered
@@ -7895,9 +7895,40 @@
     
 
     <div class="t-line-summary">
-      <b>8</b> relevant lines.
+      <b>0</b> relevant lines.
+      <span class="green"><b>0</b> lines covered</span> and
+      <span class="red"><b>0</b> lines missed.</span>
+    </div>
+
+    
+
+  </div>
+
+  <pre>
+    <ol>
+      
+    </ol>
+  </pre>
+</div>
+
+      
+        <div class="source_table" id="1730250746a5ba1a01b0b4c373931423a4163a91">
+  <div class="header">
+    <h3>spec/requests/v1/auth/registrations_spec.rb</h3>
+    <h4>
+      <span class="yellow">
+  85.71%
+</span>
+
+      lines covered
+    </h4>
+
+    
+
+    <div class="t-line-summary">
+      <b>7</b> relevant lines.
       <span class="green"><b>6</b> lines covered</span> and
-      <span class="red"><b>2</b> lines missed.</span>
+      <span class="red"><b>1</b> lines missed.</span>
     </div>
 
     
@@ -7936,7 +7967,7 @@
 
             
 
-            <code class="ruby">RSpec.describe &quot;V1::Auth::AuthUsersApis&quot;, type: :request do</code>
+            <code class="ruby">RSpec.describe &quot;V1::Auth::RegistrationsController&quot;, type: :request do</code>
           </li>
         </div>
       
@@ -7974,24 +8005,24 @@
         </div>
       
         <div>
-          <li class="covered" data-hits="1" data-linenumber="7">
+          <li class="never" data-hits="" data-linenumber="7">
+            
+            
+
+            
+
+            <code class="ruby">        # client_user = build(:user)</code>
+          </li>
+        </div>
+      
+        <div>
+          <li class="covered" data-hits="1" data-linenumber="8">
             <span class="hits">1</span>
             
 
             
 
-            <code class="ruby">        client_user = build(:user)</code>
-          </li>
-        </div>
-      
-        <div>
-          <li class="missed" data-hits="0" data-linenumber="8">
-            
-            
-
-            
-
-            <code class="ruby">        POST v1_auth_registration_path, params: client_user</code>
+            <code class="ruby">        post v1_auth_path, params = { email: &#39;test2@example.com&#39;, password: &#39;test2525&#39; } </code>
           </li>
         </div>
       
@@ -8002,7 +8033,7 @@
 
             
 
-            <code class="ruby">        expect(response).to have_http_status(:ok)</code>
+            <code class="ruby">        expect(response).to have_http_status(ok)</code>
           </li>
         </div>
       
@@ -8041,114 +8072,6 @@
       
         <div>
           <li class="never" data-hits="" data-linenumber="13">
-            
-            
-
-            
-
-            <code class="ruby">end</code>
-          </li>
-        </div>
-      
-    </ol>
-  </pre>
-</div>
-
-      
-        <div class="source_table" id="1730250746a5ba1a01b0b4c373931423a4163a91">
-  <div class="header">
-    <h3>spec/requests/v1/auth/registrations_spec.rb</h3>
-    <h4>
-      <span class="green">
-  100.0%
-</span>
-
-      lines covered
-    </h4>
-
-    
-
-    <div class="t-line-summary">
-      <b>4</b> relevant lines.
-      <span class="green"><b>4</b> lines covered</span> and
-      <span class="red"><b>0</b> lines missed.</span>
-    </div>
-
-    
-
-  </div>
-
-  <pre>
-    <ol>
-      
-        <div>
-          <li class="covered" data-hits="1" data-linenumber="1">
-            <span class="hits">1</span>
-            
-
-            
-
-            <code class="ruby">require &#39;rails_helper&#39;</code>
-          </li>
-        </div>
-      
-        <div>
-          <li class="never" data-hits="" data-linenumber="2">
-            
-            
-
-            
-
-            <code class="ruby"></code>
-          </li>
-        </div>
-      
-        <div>
-          <li class="covered" data-hits="1" data-linenumber="3">
-            <span class="hits">1</span>
-            
-
-            
-
-            <code class="ruby">RSpec.describe &quot;V1::Auth::Registrations&quot;, type: :request do</code>
-          </li>
-        </div>
-      
-        <div>
-          <li class="covered" data-hits="1" data-linenumber="4">
-            <span class="hits">1</span>
-            
-
-            
-
-            <code class="ruby">  describe &quot;GET /index&quot; do</code>
-          </li>
-        </div>
-      
-        <div>
-          <li class="covered" data-hits="1" data-linenumber="5">
-            <span class="hits">1</span>
-            
-
-            
-
-            <code class="ruby">    pending &quot;add some examples (or delete) #{__FILE__}&quot;</code>
-          </li>
-        </div>
-      
-        <div>
-          <li class="never" data-hits="" data-linenumber="6">
-            
-            
-
-            
-
-            <code class="ruby">  end</code>
-          </li>
-        </div>
-      
-        <div>
-          <li class="never" data-hits="" data-linenumber="7">
             
             
 

--- a/coverage/index.html
+++ b/coverage/index.html
@@ -14,7 +14,7 @@
       <img src="./assets/0.12.3/loading.gif" alt="loading"/>
     </div>
     <div id="wrapper" class="hide">
-      <div class="timestamp">Generated <abbr class="timeago" title="2022-06-13T23:11:19+09:00">2022-06-13T23:11:19+09:00</abbr></div>
+      <div class="timestamp">Generated <abbr class="timeago" title="2022-06-14T00:21:34+09:00">2022-06-14T00:21:34+09:00</abbr></div>
       <ul class="group_tabs"></ul>
 
       <div id="content">
@@ -23,7 +23,7 @@
     <span class="group_name">All Files</span>
     (<span class="covered_percent">
       <span class="green">
-  97.2%
+  97.22%
 </span>
 
      </span>
@@ -39,15 +39,15 @@
   <a name="AllFiles"></a>
 
   <div>
-    <b>21</b> files in total.
+    <b>22</b> files in total.
   </div>
 
   <div class="t-line-summary">
-    <b>107</b> relevant lines,
-    <span class="green"><b>104</b> lines covered</span> and
+    <b>108</b> relevant lines,
+    <span class="green"><b>105</b> lines covered</span> and
     <span class="red"><b>3</b> lines missed. </span>
     (<span class="green">
-  97.2%
+  97.22%
 </span>
 )
   </div>
@@ -271,9 +271,9 @@
           <tr class="t-file">
             <td class="strong t-file__name"><a href="#cc72e9d30e6153b22bfa9d27cd59a52a49129a11" class="src_link" title="spec/factories/users.rb">spec/factories/users.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
-            <td class="cell--number">6</td>
-            <td class="cell--number">4</td>
-            <td class="cell--number">4</td>
+            <td class="cell--number">7</td>
+            <td class="cell--number">5</td>
+            <td class="cell--number">5</td>
             <td class="cell--number">0</td>
             <td class="cell--number">1.00</td>
             
@@ -282,7 +282,7 @@
           <tr class="t-file">
             <td class="strong t-file__name"><a href="#41b9cd9b5be863914cc167be6d1e6add1e2b2236" class="src_link" title="spec/requests/v1/auth/auth_users_apis_spec.rb">spec/requests/v1/auth/auth_users_apis_spec.rb</a></td>
             <td class="yellow strong cell--number t-file__coverage">87.50 %</td>
-            <td class="cell--number">13</td>
+            <td class="cell--number">14</td>
             <td class="cell--number">8</td>
             <td class="cell--number">7</td>
             <td class="cell--number">1</td>
@@ -298,6 +298,17 @@
             <td class="cell--number">4</td>
             <td class="cell--number">0</td>
             <td class="cell--number">1.00</td>
+            
+          </tr>
+        
+          <tr class="t-file">
+            <td class="strong t-file__name"><a href="#0730d99e9555d03ffa65a09e7942a23164300943" class="src_link" title="spec/support/authorization_spec.rb">spec/support/authorization_spec.rb</a></td>
+            <td class="green strong cell--number t-file__coverage">100.00 %</td>
+            <td class="cell--number">0</td>
+            <td class="cell--number">0</td>
+            <td class="cell--number">0</td>
+            <td class="cell--number">0</td>
+            <td class="cell--number">0.00</td>
             
           </tr>
         
@@ -7864,8 +7875,8 @@
     
 
     <div class="t-line-summary">
-      <b>4</b> relevant lines.
-      <span class="green"><b>4</b> lines covered</span> and
+      <b>5</b> relevant lines.
+      <span class="green"><b>5</b> lines covered</span> and
       <span class="red"><b>0</b> lines missed.</span>
     </div>
 
@@ -7921,7 +7932,18 @@
         </div>
       
         <div>
-          <li class="never" data-hits="" data-linenumber="5">
+          <li class="covered" data-hits="1" data-linenumber="5">
+            <span class="hits">1</span>
+            
+
+            
+
+            <code class="ruby">    sequence(:password_confirmation) { |n| &quot;test#{n}111&quot; }</code>
+          </li>
+        </div>
+      
+        <div>
+          <li class="never" data-hits="" data-linenumber="6">
             
             
 
@@ -7932,7 +7954,7 @@
         </div>
       
         <div>
-          <li class="never" data-hits="" data-linenumber="6">
+          <li class="never" data-hits="" data-linenumber="7">
             
             
 
@@ -8040,13 +8062,13 @@
         </div>
       
         <div>
-          <li class="covered" data-hits="1" data-linenumber="7">
-            <span class="hits">1</span>
+          <li class="never" data-hits="" data-linenumber="7">
+            
             
 
             
 
-            <code class="ruby">        params = { email: &#39;test2@example.com&#39;, password: &#39;test2525&#39; }</code>
+            <code class="ruby">        # user = create(:user)</code>
           </li>
         </div>
       
@@ -8057,29 +8079,29 @@
 
             
 
-            <code class="ruby">        post v1_auth_path, params: params</code>
+            <code class="ruby">        params = { email: &#39;test@example.com&#39;, password: &#39;test2525&#39;, password_confirmation: &#39;test2525&#39; } </code>
           </li>
         </div>
       
         <div>
-          <li class="missed" data-hits="0" data-linenumber="9">
-            
-            
-
+          <li class="covered" data-hits="1" data-linenumber="9">
+            <span class="hits">1</span>
             
 
-            <code class="ruby">        expect(response).to have_http_status(ok)</code>
+            
+
+            <code class="ruby">        post v1_auth_sessions_path, params: params</code>
           </li>
         </div>
       
         <div>
-          <li class="never" data-hits="" data-linenumber="10">
+          <li class="missed" data-hits="0" data-linenumber="10">
             
             
 
             
 
-            <code class="ruby">      end</code>
+            <code class="ruby">        expect(response).to have_http_status &quot;200&quot;</code>
           </li>
         </div>
       
@@ -8090,7 +8112,7 @@
 
             
 
-            <code class="ruby">    end</code>
+            <code class="ruby">      end</code>
           </li>
         </div>
       
@@ -8101,12 +8123,23 @@
 
             
 
-            <code class="ruby">  end</code>
+            <code class="ruby">    end</code>
           </li>
         </div>
       
         <div>
           <li class="never" data-hits="" data-linenumber="13">
+            
+            
+
+            
+
+            <code class="ruby">  end</code>
+          </li>
+        </div>
+      
+        <div>
+          <li class="never" data-hits="" data-linenumber="14">
             
             
 
@@ -8223,6 +8256,37 @@
             <code class="ruby">end</code>
           </li>
         </div>
+      
+    </ol>
+  </pre>
+</div>
+
+      
+        <div class="source_table" id="0730d99e9555d03ffa65a09e7942a23164300943">
+  <div class="header">
+    <h3>spec/support/authorization_spec.rb</h3>
+    <h4>
+      <span class="green">
+  100.0%
+</span>
+
+      lines covered
+    </h4>
+
+    
+
+    <div class="t-line-summary">
+      <b>0</b> relevant lines.
+      <span class="green"><b>0</b> lines covered</span> and
+      <span class="red"><b>0</b> lines missed.</span>
+    </div>
+
+    
+
+  </div>
+
+  <pre>
+    <ol>
       
     </ol>
   </pre>

--- a/coverage/index.html
+++ b/coverage/index.html
@@ -14,7 +14,7 @@
       <img src="./assets/0.12.3/loading.gif" alt="loading"/>
     </div>
     <div id="wrapper" class="hide">
-      <div class="timestamp">Generated <abbr class="timeago" title="2022-06-10T21:55:28+09:00">2022-06-10T21:55:28+09:00</abbr></div>
+      <div class="timestamp">Generated <abbr class="timeago" title="2022-06-13T17:40:06+09:00">2022-06-13T17:40:06+09:00</abbr></div>
       <ul class="group_tabs"></ul>
 
       <div id="content">
@@ -23,14 +23,14 @@
     <span class="group_name">All Files</span>
     (<span class="covered_percent">
       <span class="green">
-  100.0%
+  96.15%
 </span>
 
      </span>
      covered at
      <span class="covered_strength">
-       <span class="yellow">
-         1.0
+       <span class="red">
+         0.96
        </span>
     </span> hits/line
     )
@@ -39,15 +39,15 @@
   <a name="AllFiles"></a>
 
   <div>
-    <b>19</b> files in total.
+    <b>21</b> files in total.
   </div>
 
   <div class="t-line-summary">
-    <b>80</b> relevant lines,
-    <span class="green"><b>80</b> lines covered</span> and
-    <span class="red"><b>0</b> lines missed. </span>
+    <b>104</b> relevant lines,
+    <span class="green"><b>100</b> lines covered</span> and
+    <span class="red"><b>4</b> lines missed. </span>
     (<span class="green">
-  100.0%
+  96.15%
 </span>
 )
   </div>
@@ -106,7 +106,7 @@
           <tr class="t-file">
             <td class="strong t-file__name"><a href="#4a07c80a4841a4bea1d05c6d98daf9bb801c62d0" class="src_link" title="app/models/user.rb">app/models/user.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
-            <td class="cell--number">9</td>
+            <td class="cell--number">10</td>
             <td class="cell--number">3</td>
             <td class="cell--number">3</td>
             <td class="cell--number">0</td>
@@ -195,8 +195,8 @@
             <td class="strong t-file__name"><a href="#3e5bfb12b2a9c84d3427bcc77349206dfae99cce" class="src_link" title="config/initializers/devise.rb">config/initializers/devise.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
             <td class="cell--number">311</td>
-            <td class="cell--number">13</td>
-            <td class="cell--number">13</td>
+            <td class="cell--number">18</td>
+            <td class="cell--number">18</td>
             <td class="cell--number">0</td>
             <td class="cell--number">1.00</td>
             
@@ -248,19 +248,30 @@
         
           <tr class="t-file">
             <td class="strong t-file__name"><a href="#36a1cbacc4051f98cd0197a9af2b7491f59770ed" class="src_link" title="config/initializers/rails_admin.rb">config/initializers/rails_admin.rb</a></td>
-            <td class="green strong cell--number t-file__coverage">100.00 %</td>
-            <td class="cell--number">42</td>
-            <td class="cell--number">12</td>
-            <td class="cell--number">12</td>
-            <td class="cell--number">0</td>
-            <td class="cell--number">1.00</td>
+            <td class="yellow strong cell--number t-file__coverage">86.67 %</td>
+            <td class="cell--number">48</td>
+            <td class="cell--number">15</td>
+            <td class="cell--number">13</td>
+            <td class="cell--number">2</td>
+            <td class="cell--number">0.87</td>
             
           </tr>
         
           <tr class="t-file">
             <td class="strong t-file__name"><a href="#056289cd38b96f93ffdda478bab2d38195c6ce01" class="src_link" title="config/routes.rb">config/routes.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
+            <td class="cell--number">7</td>
             <td class="cell--number">5</td>
+            <td class="cell--number">5</td>
+            <td class="cell--number">0</td>
+            <td class="cell--number">1.00</td>
+            
+          </tr>
+        
+          <tr class="t-file">
+            <td class="strong t-file__name"><a href="#cc72e9d30e6153b22bfa9d27cd59a52a49129a11" class="src_link" title="spec/factories/users.rb">spec/factories/users.rb</a></td>
+            <td class="green strong cell--number t-file__coverage">100.00 %</td>
+            <td class="cell--number">6</td>
             <td class="cell--number">4</td>
             <td class="cell--number">4</td>
             <td class="cell--number">0</td>
@@ -269,11 +280,22 @@
           </tr>
         
           <tr class="t-file">
-            <td class="strong t-file__name"><a href="#1bb692b038338426f94d350cd0292ddd179d8165" class="src_link" title="spec/factories/posts.rb">spec/factories/posts.rb</a></td>
+            <td class="strong t-file__name"><a href="#41b9cd9b5be863914cc167be6d1e6add1e2b2236" class="src_link" title="spec/requests/v1/auth/auth_users_apis_spec.rb">spec/requests/v1/auth/auth_users_apis_spec.rb</a></td>
+            <td class="red strong cell--number t-file__coverage">75.00 %</td>
+            <td class="cell--number">13</td>
+            <td class="cell--number">8</td>
+            <td class="cell--number">6</td>
+            <td class="cell--number">2</td>
+            <td class="cell--number">0.75</td>
+            
+          </tr>
+        
+          <tr class="t-file">
+            <td class="strong t-file__name"><a href="#1730250746a5ba1a01b0b4c373931423a4163a91" class="src_link" title="spec/requests/v1/auth/registrations_spec.rb">spec/requests/v1/auth/registrations_spec.rb</a></td>
             <td class="green strong cell--number t-file__coverage">100.00 %</td>
+            <td class="cell--number">7</td>
             <td class="cell--number">4</td>
-            <td class="cell--number">1</td>
-            <td class="cell--number">1</td>
+            <td class="cell--number">4</td>
             <td class="cell--number">0</td>
             <td class="cell--number">1.00</td>
             
@@ -565,12 +587,23 @@
 
             
 
-            <code class="ruby">         :recoverable, :rememberable, :validatable</code>
+            <code class="ruby">         :recoverable, :rememberable, :validatable,</code>
           </li>
         </div>
       
         <div>
-          <li class="covered" data-hits="1" data-linenumber="8">
+          <li class="never" data-hits="" data-linenumber="8">
+            
+            
+
+            
+
+            <code class="ruby">         :lockable</code>
+          </li>
+        </div>
+      
+        <div>
+          <li class="covered" data-hits="1" data-linenumber="9">
             <span class="hits">1</span>
             
 
@@ -581,7 +614,7 @@
         </div>
       
         <div>
-          <li class="never" data-hits="" data-linenumber="9">
+          <li class="never" data-hits="" data-linenumber="10">
             
             
 
@@ -2477,8 +2510,8 @@
     
 
     <div class="t-line-summary">
-      <b>13</b> relevant lines.
-      <span class="green"><b>13</b> lines covered</span> and
+      <b>18</b> relevant lines.
+      <span class="green"><b>18</b> lines covered</span> and
       <span class="red"><b>0</b> lines missed.</span>
     </div>
 
@@ -4646,13 +4679,13 @@
         </div>
       
         <div>
-          <li class="never" data-hits="" data-linenumber="197">
-            
-            
-
+          <li class="covered" data-hits="1" data-linenumber="197">
+            <span class="hits">1</span>
             
 
-            <code class="ruby">  # config.lock_strategy = :failed_attempts</code>
+            
+
+            <code class="ruby">  config.lock_strategy = :failed_attempts</code>
           </li>
         </div>
       
@@ -4756,13 +4789,13 @@
         </div>
       
         <div>
-          <li class="never" data-hits="" data-linenumber="207">
-            
-            
-
+          <li class="covered" data-hits="1" data-linenumber="207">
+            <span class="hits">1</span>
             
 
-            <code class="ruby">  # config.unlock_strategy = :both</code>
+            
+
+            <code class="ruby">  config.unlock_strategy = :time</code>
           </li>
         </div>
       
@@ -4800,13 +4833,13 @@
         </div>
       
         <div>
-          <li class="never" data-hits="" data-linenumber="211">
-            
-            
-
+          <li class="covered" data-hits="1" data-linenumber="211">
+            <span class="hits">1</span>
             
 
-            <code class="ruby">  # config.maximum_attempts = 20</code>
+            
+
+            <code class="ruby">  config.maximum_attempts = 10</code>
           </li>
         </div>
       
@@ -4833,13 +4866,13 @@
         </div>
       
         <div>
-          <li class="never" data-hits="" data-linenumber="214">
-            
-            
-
+          <li class="covered" data-hits="1" data-linenumber="214">
+            <span class="hits">1</span>
             
 
-            <code class="ruby">  # config.unlock_in = 1.hour</code>
+            
+
+            <code class="ruby">  config.unlock_in = 1.hour</code>
           </li>
         </div>
       
@@ -4866,13 +4899,13 @@
         </div>
       
         <div>
-          <li class="never" data-hits="" data-linenumber="217">
-            
-            
-
+          <li class="covered" data-hits="1" data-linenumber="217">
+            <span class="hits">1</span>
             
 
-            <code class="ruby">  # config.last_attempt_warning = true</code>
+            
+
+            <code class="ruby">  config.last_attempt_warning = true</code>
           </li>
         </div>
       
@@ -7088,8 +7121,8 @@
   <div class="header">
     <h3>config/initializers/rails_admin.rb</h3>
     <h4>
-      <span class="green">
-  100.0%
+      <span class="yellow">
+  86.67%
 </span>
 
       lines covered
@@ -7098,9 +7131,9 @@
     
 
     <div class="t-line-summary">
-      <b>12</b> relevant lines.
-      <span class="green"><b>12</b> lines covered</span> and
-      <span class="red"><b>0</b> lines missed.</span>
+      <b>15</b> relevant lines.
+      <span class="green"><b>13</b> lines covered</span> and
+      <span class="red"><b>2</b> lines missed.</span>
     </div>
 
     
@@ -7144,35 +7177,35 @@
         </div>
       
         <div>
-          <li class="never" data-hits="" data-linenumber="4">
-            
-            
-
+          <li class="covered" data-hits="1" data-linenumber="4">
+            <span class="hits">1</span>
             
 
-            <code class="ruby">  ### Popular gems integration</code>
+            
+
+            <code class="ruby">  config.authenticate_with do</code>
           </li>
         </div>
       
         <div>
-          <li class="never" data-hits="" data-linenumber="5">
+          <li class="missed" data-hits="0" data-linenumber="5">
             
             
 
             
 
-            <code class="ruby"></code>
+            <code class="ruby">    authenticate_or_request_with_http_basic(&#39;Site Message&#39;) do |username, password|</code>
           </li>
         </div>
       
         <div>
-          <li class="never" data-hits="" data-linenumber="6">
+          <li class="missed" data-hits="0" data-linenumber="6">
             
             
 
             
 
-            <code class="ruby">  ## == Devise ==</code>
+            <code class="ruby">      username == ENV[&#39;ADMIN_NAME&#39;] &amp;&amp; password == ENV[&#39;ADMIN_PASSWORD&#39;]</code>
           </li>
         </div>
       
@@ -7183,7 +7216,7 @@
 
             
 
-            <code class="ruby">  # config.authenticate_with do</code>
+            <code class="ruby">    end</code>
           </li>
         </div>
       
@@ -7194,7 +7227,7 @@
 
             
 
-            <code class="ruby">  #   warden.authenticate! scope: :user</code>
+            <code class="ruby">  end</code>
           </li>
         </div>
       
@@ -7205,7 +7238,7 @@
 
             
 
-            <code class="ruby">  # end</code>
+            <code class="ruby"></code>
           </li>
         </div>
       
@@ -7216,7 +7249,7 @@
 
             
 
-            <code class="ruby">  # config.current_user_method(&amp;:current_user)</code>
+            <code class="ruby">  ### Popular gems integration</code>
           </li>
         </div>
       
@@ -7238,7 +7271,7 @@
 
             
 
-            <code class="ruby">  ## == CancanCan ==</code>
+            <code class="ruby">  ## == Devise ==</code>
           </li>
         </div>
       
@@ -7249,7 +7282,7 @@
 
             
 
-            <code class="ruby">  # config.authorize_with :cancancan</code>
+            <code class="ruby">  # config.authenticate_with do</code>
           </li>
         </div>
       
@@ -7260,7 +7293,7 @@
 
             
 
-            <code class="ruby"></code>
+            <code class="ruby">  #   warden.authenticate! scope: :user</code>
           </li>
         </div>
       
@@ -7271,7 +7304,7 @@
 
             
 
-            <code class="ruby">  ## == Pundit ==</code>
+            <code class="ruby">  # end</code>
           </li>
         </div>
       
@@ -7282,7 +7315,7 @@
 
             
 
-            <code class="ruby">  # config.authorize_with :pundit</code>
+            <code class="ruby">  # config.current_user_method(&amp;:current_user)</code>
           </li>
         </div>
       
@@ -7304,7 +7337,7 @@
 
             
 
-            <code class="ruby">  ## == PaperTrail ==</code>
+            <code class="ruby">  ## == CancanCan ==</code>
           </li>
         </div>
       
@@ -7315,7 +7348,7 @@
 
             
 
-            <code class="ruby">  # config.audit_with :paper_trail, &#39;User&#39;, &#39;PaperTrail::Version&#39; # PaperTrail &gt;= 3.0.0</code>
+            <code class="ruby">  # config.authorize_with :cancancan</code>
           </li>
         </div>
       
@@ -7337,7 +7370,7 @@
 
             
 
-            <code class="ruby">  ### More at https://github.com/railsadminteam/rails_admin/wiki/Base-configuration</code>
+            <code class="ruby">  ## == Pundit ==</code>
           </li>
         </div>
       
@@ -7348,7 +7381,7 @@
 
             
 
-            <code class="ruby"></code>
+            <code class="ruby">  # config.authorize_with :pundit</code>
           </li>
         </div>
       
@@ -7359,7 +7392,7 @@
 
             
 
-            <code class="ruby">  ## == Gravatar integration ==</code>
+            <code class="ruby"></code>
           </li>
         </div>
       
@@ -7370,7 +7403,7 @@
 
             
 
-            <code class="ruby">  ## To disable Gravatar integration in Navigation Bar set to false</code>
+            <code class="ruby">  ## == PaperTrail ==</code>
           </li>
         </div>
       
@@ -7381,7 +7414,7 @@
 
             
 
-            <code class="ruby">  # config.show_gravatar = true</code>
+            <code class="ruby">  # config.audit_with :paper_trail, &#39;User&#39;, &#39;PaperTrail::Version&#39; # PaperTrail &gt;= 3.0.0</code>
           </li>
         </div>
       
@@ -7397,117 +7430,18 @@
         </div>
       
         <div>
-          <li class="covered" data-hits="1" data-linenumber="27">
-            <span class="hits">1</span>
+          <li class="never" data-hits="" data-linenumber="27">
+            
             
 
             
 
-            <code class="ruby">  config.actions do</code>
+            <code class="ruby">  ### More at https://github.com/railsadminteam/rails_admin/wiki/Base-configuration</code>
           </li>
         </div>
       
         <div>
-          <li class="covered" data-hits="1" data-linenumber="28">
-            <span class="hits">1</span>
-            
-
-            
-
-            <code class="ruby">    dashboard                     # mandatory</code>
-          </li>
-        </div>
-      
-        <div>
-          <li class="covered" data-hits="1" data-linenumber="29">
-            <span class="hits">1</span>
-            
-
-            
-
-            <code class="ruby">    index                         # mandatory</code>
-          </li>
-        </div>
-      
-        <div>
-          <li class="covered" data-hits="1" data-linenumber="30">
-            <span class="hits">1</span>
-            
-
-            
-
-            <code class="ruby">    new</code>
-          </li>
-        </div>
-      
-        <div>
-          <li class="covered" data-hits="1" data-linenumber="31">
-            <span class="hits">1</span>
-            
-
-            
-
-            <code class="ruby">    export</code>
-          </li>
-        </div>
-      
-        <div>
-          <li class="covered" data-hits="1" data-linenumber="32">
-            <span class="hits">1</span>
-            
-
-            
-
-            <code class="ruby">    bulk_delete</code>
-          </li>
-        </div>
-      
-        <div>
-          <li class="covered" data-hits="1" data-linenumber="33">
-            <span class="hits">1</span>
-            
-
-            
-
-            <code class="ruby">    show</code>
-          </li>
-        </div>
-      
-        <div>
-          <li class="covered" data-hits="1" data-linenumber="34">
-            <span class="hits">1</span>
-            
-
-            
-
-            <code class="ruby">    edit</code>
-          </li>
-        </div>
-      
-        <div>
-          <li class="covered" data-hits="1" data-linenumber="35">
-            <span class="hits">1</span>
-            
-
-            
-
-            <code class="ruby">    delete</code>
-          </li>
-        </div>
-      
-        <div>
-          <li class="covered" data-hits="1" data-linenumber="36">
-            <span class="hits">1</span>
-            
-
-            
-
-            <code class="ruby">    show_in_app</code>
-          </li>
-        </div>
-      
-        <div>
-          <li class="never" data-hits="" data-linenumber="37">
+          <li class="never" data-hits="" data-linenumber="28">
             
             
 
@@ -7518,7 +7452,172 @@
         </div>
       
         <div>
-          <li class="never" data-hits="" data-linenumber="38">
+          <li class="never" data-hits="" data-linenumber="29">
+            
+            
+
+            
+
+            <code class="ruby">  ## == Gravatar integration ==</code>
+          </li>
+        </div>
+      
+        <div>
+          <li class="never" data-hits="" data-linenumber="30">
+            
+            
+
+            
+
+            <code class="ruby">  ## To disable Gravatar integration in Navigation Bar set to false</code>
+          </li>
+        </div>
+      
+        <div>
+          <li class="never" data-hits="" data-linenumber="31">
+            
+            
+
+            
+
+            <code class="ruby">  # config.show_gravatar = true</code>
+          </li>
+        </div>
+      
+        <div>
+          <li class="never" data-hits="" data-linenumber="32">
+            
+            
+
+            
+
+            <code class="ruby"></code>
+          </li>
+        </div>
+      
+        <div>
+          <li class="covered" data-hits="1" data-linenumber="33">
+            <span class="hits">1</span>
+            
+
+            
+
+            <code class="ruby">  config.actions do</code>
+          </li>
+        </div>
+      
+        <div>
+          <li class="covered" data-hits="1" data-linenumber="34">
+            <span class="hits">1</span>
+            
+
+            
+
+            <code class="ruby">    dashboard                     # mandatory</code>
+          </li>
+        </div>
+      
+        <div>
+          <li class="covered" data-hits="1" data-linenumber="35">
+            <span class="hits">1</span>
+            
+
+            
+
+            <code class="ruby">    index                         # mandatory</code>
+          </li>
+        </div>
+      
+        <div>
+          <li class="covered" data-hits="1" data-linenumber="36">
+            <span class="hits">1</span>
+            
+
+            
+
+            <code class="ruby">    new</code>
+          </li>
+        </div>
+      
+        <div>
+          <li class="covered" data-hits="1" data-linenumber="37">
+            <span class="hits">1</span>
+            
+
+            
+
+            <code class="ruby">    export</code>
+          </li>
+        </div>
+      
+        <div>
+          <li class="covered" data-hits="1" data-linenumber="38">
+            <span class="hits">1</span>
+            
+
+            
+
+            <code class="ruby">    bulk_delete</code>
+          </li>
+        </div>
+      
+        <div>
+          <li class="covered" data-hits="1" data-linenumber="39">
+            <span class="hits">1</span>
+            
+
+            
+
+            <code class="ruby">    show</code>
+          </li>
+        </div>
+      
+        <div>
+          <li class="covered" data-hits="1" data-linenumber="40">
+            <span class="hits">1</span>
+            
+
+            
+
+            <code class="ruby">    edit</code>
+          </li>
+        </div>
+      
+        <div>
+          <li class="covered" data-hits="1" data-linenumber="41">
+            <span class="hits">1</span>
+            
+
+            
+
+            <code class="ruby">    delete</code>
+          </li>
+        </div>
+      
+        <div>
+          <li class="covered" data-hits="1" data-linenumber="42">
+            <span class="hits">1</span>
+            
+
+            
+
+            <code class="ruby">    show_in_app</code>
+          </li>
+        </div>
+      
+        <div>
+          <li class="never" data-hits="" data-linenumber="43">
+            
+            
+
+            
+
+            <code class="ruby"></code>
+          </li>
+        </div>
+      
+        <div>
+          <li class="never" data-hits="" data-linenumber="44">
             
             
 
@@ -7529,7 +7628,7 @@
         </div>
       
         <div>
-          <li class="never" data-hits="" data-linenumber="39">
+          <li class="never" data-hits="" data-linenumber="45">
             
             
 
@@ -7540,7 +7639,7 @@
         </div>
       
         <div>
-          <li class="never" data-hits="" data-linenumber="40">
+          <li class="never" data-hits="" data-linenumber="46">
             
             
 
@@ -7551,7 +7650,7 @@
         </div>
       
         <div>
-          <li class="never" data-hits="" data-linenumber="41">
+          <li class="never" data-hits="" data-linenumber="47">
             
             
 
@@ -7562,7 +7661,7 @@
         </div>
       
         <div>
-          <li class="never" data-hits="" data-linenumber="42">
+          <li class="never" data-hits="" data-linenumber="48">
             
             
 
@@ -7580,6 +7679,114 @@
         <div class="source_table" id="056289cd38b96f93ffdda478bab2d38195c6ce01">
   <div class="header">
     <h3>config/routes.rb</h3>
+    <h4>
+      <span class="green">
+  100.0%
+</span>
+
+      lines covered
+    </h4>
+
+    
+
+    <div class="t-line-summary">
+      <b>5</b> relevant lines.
+      <span class="green"><b>5</b> lines covered</span> and
+      <span class="red"><b>0</b> lines missed.</span>
+    </div>
+
+    
+
+  </div>
+
+  <pre>
+    <ol>
+      
+        <div>
+          <li class="covered" data-hits="1" data-linenumber="1">
+            <span class="hits">1</span>
+            
+
+            
+
+            <code class="ruby">Rails.application.routes.draw do</code>
+          </li>
+        </div>
+      
+        <div>
+          <li class="covered" data-hits="1" data-linenumber="2">
+            <span class="hits">1</span>
+            
+
+            
+
+            <code class="ruby">  namespace :v1 do</code>
+          </li>
+        </div>
+      
+        <div>
+          <li class="covered" data-hits="1" data-linenumber="3">
+            <span class="hits">1</span>
+            
+
+            
+
+            <code class="ruby">    mount_devise_token_auth_for &#39;User&#39;, at: &#39;auth&#39;</code>
+          </li>
+        </div>
+      
+        <div>
+          <li class="covered" data-hits="1" data-linenumber="4">
+            <span class="hits">1</span>
+            
+
+            
+
+            <code class="ruby">    mount RailsAdmin::Engine =&gt; &#39;/admin&#39;, as: &#39;rails_admin&#39;</code>
+          </li>
+        </div>
+      
+        <div>
+          <li class="never" data-hits="" data-linenumber="5">
+            
+            
+
+            
+
+            <code class="ruby">  end</code>
+          </li>
+        </div>
+      
+        <div>
+          <li class="covered" data-hits="1" data-linenumber="6">
+            <span class="hits">1</span>
+            
+
+            
+
+            <code class="ruby">  resources :posts, only: :index</code>
+          </li>
+        </div>
+      
+        <div>
+          <li class="never" data-hits="" data-linenumber="7">
+            
+            
+
+            
+
+            <code class="ruby">end</code>
+          </li>
+        </div>
+      
+    </ol>
+  </pre>
+</div>
+
+      
+        <div class="source_table" id="cc72e9d30e6153b22bfa9d27cd59a52a49129a11">
+  <div class="header">
+    <h3>spec/factories/users.rb</h3>
     <h4>
       <span class="green">
   100.0%
@@ -7610,7 +7817,7 @@
 
             
 
-            <code class="ruby">Rails.application.routes.draw do</code>
+            <code class="ruby">FactoryBot.define do</code>
           </li>
         </div>
       
@@ -7621,7 +7828,7 @@
 
             
 
-            <code class="ruby">  mount_devise_token_auth_for &#39;User&#39;, at: &#39;auth&#39;</code>
+            <code class="ruby">  factory :user do</code>
           </li>
         </div>
       
@@ -7632,7 +7839,7 @@
 
             
 
-            <code class="ruby">  mount RailsAdmin::Engine =&gt; &#39;/admin&#39;, as: &#39;rails_admin&#39;</code>
+            <code class="ruby">    sequence(:email) { |n| &quot;test#{n}@gmail.com&quot; }</code>
           </li>
         </div>
       
@@ -7643,12 +7850,23 @@
 
             
 
-            <code class="ruby">  resources :posts, only: :index</code>
+            <code class="ruby">    sequence(:password) { |n| &quot;test#{n}111&quot; }</code>
           </li>
         </div>
       
         <div>
           <li class="never" data-hits="" data-linenumber="5">
+            
+            
+
+            
+
+            <code class="ruby">  end</code>
+          </li>
+        </div>
+      
+        <div>
+          <li class="never" data-hits="" data-linenumber="6">
             
             
 
@@ -7663,9 +7881,183 @@
 </div>
 
       
-        <div class="source_table" id="1bb692b038338426f94d350cd0292ddd179d8165">
+        <div class="source_table" id="41b9cd9b5be863914cc167be6d1e6add1e2b2236">
   <div class="header">
-    <h3>spec/factories/posts.rb</h3>
+    <h3>spec/requests/v1/auth/auth_users_apis_spec.rb</h3>
+    <h4>
+      <span class="red">
+  75.0%
+</span>
+
+      lines covered
+    </h4>
+
+    
+
+    <div class="t-line-summary">
+      <b>8</b> relevant lines.
+      <span class="green"><b>6</b> lines covered</span> and
+      <span class="red"><b>2</b> lines missed.</span>
+    </div>
+
+    
+
+  </div>
+
+  <pre>
+    <ol>
+      
+        <div>
+          <li class="covered" data-hits="1" data-linenumber="1">
+            <span class="hits">1</span>
+            
+
+            
+
+            <code class="ruby">require &#39;rails_helper&#39;</code>
+          </li>
+        </div>
+      
+        <div>
+          <li class="never" data-hits="" data-linenumber="2">
+            
+            
+
+            
+
+            <code class="ruby"></code>
+          </li>
+        </div>
+      
+        <div>
+          <li class="covered" data-hits="1" data-linenumber="3">
+            <span class="hits">1</span>
+            
+
+            
+
+            <code class="ruby">RSpec.describe &quot;V1::Auth::AuthUsersApis&quot;, type: :request do</code>
+          </li>
+        </div>
+      
+        <div>
+          <li class="covered" data-hits="1" data-linenumber="4">
+            <span class="hits">1</span>
+            
+
+            
+
+            <code class="ruby">  describe &quot;POST /v1/auth #create&quot; do</code>
+          </li>
+        </div>
+      
+        <div>
+          <li class="covered" data-hits="1" data-linenumber="5">
+            <span class="hits">1</span>
+            
+
+            
+
+            <code class="ruby">    context &quot;新規登録が成功した場合&quot; do</code>
+          </li>
+        </div>
+      
+        <div>
+          <li class="covered" data-hits="1" data-linenumber="6">
+            <span class="hits">1</span>
+            
+
+            
+
+            <code class="ruby">      it &quot;HTTP status 200が帰ってくること&quot; do</code>
+          </li>
+        </div>
+      
+        <div>
+          <li class="covered" data-hits="1" data-linenumber="7">
+            <span class="hits">1</span>
+            
+
+            
+
+            <code class="ruby">        client_user = build(:user)</code>
+          </li>
+        </div>
+      
+        <div>
+          <li class="missed" data-hits="0" data-linenumber="8">
+            
+            
+
+            
+
+            <code class="ruby">        POST v1_auth_registration_path, params: client_user</code>
+          </li>
+        </div>
+      
+        <div>
+          <li class="missed" data-hits="0" data-linenumber="9">
+            
+            
+
+            
+
+            <code class="ruby">        expect(response).to have_http_status(:ok)</code>
+          </li>
+        </div>
+      
+        <div>
+          <li class="never" data-hits="" data-linenumber="10">
+            
+            
+
+            
+
+            <code class="ruby">      end</code>
+          </li>
+        </div>
+      
+        <div>
+          <li class="never" data-hits="" data-linenumber="11">
+            
+            
+
+            
+
+            <code class="ruby">    end</code>
+          </li>
+        </div>
+      
+        <div>
+          <li class="never" data-hits="" data-linenumber="12">
+            
+            
+
+            
+
+            <code class="ruby">  end</code>
+          </li>
+        </div>
+      
+        <div>
+          <li class="never" data-hits="" data-linenumber="13">
+            
+            
+
+            
+
+            <code class="ruby">end</code>
+          </li>
+        </div>
+      
+    </ol>
+  </pre>
+</div>
+
+      
+        <div class="source_table" id="1730250746a5ba1a01b0b4c373931423a4163a91">
+  <div class="header">
+    <h3>spec/requests/v1/auth/registrations_spec.rb</h3>
     <h4>
       <span class="green">
   100.0%
@@ -7677,8 +8069,8 @@
     
 
     <div class="t-line-summary">
-      <b>1</b> relevant lines.
-      <span class="green"><b>1</b> lines covered</span> and
+      <b>4</b> relevant lines.
+      <span class="green"><b>4</b> lines covered</span> and
       <span class="red"><b>0</b> lines missed.</span>
     </div>
 
@@ -7696,7 +8088,7 @@
 
             
 
-            <code class="ruby">FactoryBot.define do</code>
+            <code class="ruby">require &#39;rails_helper&#39;</code>
           </li>
         </div>
       
@@ -7707,23 +8099,56 @@
 
             
 
-            <code class="ruby">  # factory :post do</code>
+            <code class="ruby"></code>
           </li>
         </div>
       
         <div>
-          <li class="never" data-hits="" data-linenumber="3">
+          <li class="covered" data-hits="1" data-linenumber="3">
+            <span class="hits">1</span>
+            
+
+            
+
+            <code class="ruby">RSpec.describe &quot;V1::Auth::Registrations&quot;, type: :request do</code>
+          </li>
+        </div>
+      
+        <div>
+          <li class="covered" data-hits="1" data-linenumber="4">
+            <span class="hits">1</span>
+            
+
+            
+
+            <code class="ruby">  describe &quot;GET /index&quot; do</code>
+          </li>
+        </div>
+      
+        <div>
+          <li class="covered" data-hits="1" data-linenumber="5">
+            <span class="hits">1</span>
+            
+
+            
+
+            <code class="ruby">    pending &quot;add some examples (or delete) #{__FILE__}&quot;</code>
+          </li>
+        </div>
+      
+        <div>
+          <li class="never" data-hits="" data-linenumber="6">
             
             
 
             
 
-            <code class="ruby">  # end</code>
+            <code class="ruby">  end</code>
           </li>
         </div>
       
         <div>
-          <li class="never" data-hits="" data-linenumber="4">
+          <li class="never" data-hits="" data-linenumber="7">
             
             
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,15 +1,3 @@
-# This file is auto-generated from the current state of the database. Instead
-# of editing this file, please use the migrations feature of Active Record to
-# incrementally modify your database, and then regenerate this schema definition.
-#
-# This file is the source Rails uses to define your schema when running `bin/rails
-# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
-# be faster and is potentially less error prone than running all of your
-# migrations from scratch. Old migrations may fail to apply correctly if those
-# migrations use external dependencies or application code.
-#
-# It's strongly recommended that you check this file into your version control system.
-
 ActiveRecord::Schema[7.0].define(version: 2022_06_11_134858) do
   create_table "posts", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "title"

--- a/spec/factories/posts.rb
+++ b/spec/factories/posts.rb
@@ -1,4 +1,0 @@
-FactoryBot.define do
-  # factory :post do
-  # end
-end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :user do
+    sequence(:email) { |n| "test#{n}@gmail.com" }
+    sequence(:password) { |n| "test#{n}111" }
+    sequence(:password_confirmation) { |n| "test#{n}111" }
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -23,7 +23,7 @@ require 'rspec/rails'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-# Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
+Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.
@@ -35,8 +35,8 @@ rescue ActiveRecord::PendingMigrationError => e
 end
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
-  config.fixture_path = "#{::Rails.root}/spec/fixtures"
-
+  # config.fixture_path = "#{::Rails.root}/spec/fixtures"
+  config.include FactoryBot::Syntax::Methods
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false
   # instead of true.

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -37,6 +37,7 @@ RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   # config.fixture_path = "#{::Rails.root}/spec/fixtures"
   config.include FactoryBot::Syntax::Methods
+  # config.include AuthorizationHelper, type: :request
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false
   # instead of true.

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -23,7 +23,7 @@ require 'rspec/rails'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
+Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.

--- a/spec/requests/v1/auth/auth_users_apis_spec.rb
+++ b/spec/requests/v1/auth/auth_users_apis_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.describe "V1::Auth::RegistrationsController", type: :request do
+  describe "POST /v1/auth #create" do
+    context "新規登録が成功した場合" do
+      it "HTTP status 200が帰ってくること" do
+        # user = create(:user)
+        params = { email: 'test@example.com', password: 'test2525', password_confirmation: 'test2525' } 
+        post v1_auth_sessions_path, params: params
+        expect(response).to have_http_status "200"
+      end
+    end
+  end
+end

--- a/spec/requests/v1/auth/registrations_spec.rb
+++ b/spec/requests/v1/auth/registrations_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "V1::Auth::Registrations", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end

--- a/spec/requests/v1/hotels_spec.rb
+++ b/spec/requests/v1/hotels_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "V1::Hotels", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end


### PR DESCRIPTION
### 【何をした？】
- **Rubocop**
  - rspecのcontextで日本語が使えるようにContext/Wordingをfalseにした
- **Controller**
  - devise_token_authのinclude及びdeviseのヘルパーメソッド導入
  - CSRF 対策をAPI通信のために無効にした
-  **Devise & Devise_Token_Auth**
   - デフォルトではemailの正規表現が甘かったので変更&パスワードを8文字以上に変更
   - uid,client,access-token,token-type,expiryをcorsに追加
   - フロントエンドで受け取るヘッダーをexposeで設定  